### PR TITLE
Fixed getenforce binary path

### DIFF
--- a/roles/zabbix_agent/tasks/Linux.yml
+++ b/roles/zabbix_agent/tasks/Linux.yml
@@ -88,7 +88,7 @@
   become: yes
 
 - name: "Collect getenforce output"
-  command: getenforce
+  command: /usr/sbin/getenforce
   register: sestatus
   when: 'getenforce_bin.stat.exists'
   changed_when: false


### PR DESCRIPTION
Running by default role code is checking for getenforce binary using full path "/usr/sbin/getnforce". But, in case the binary exists Ansible tries to launch command using binary basename 'getenforce'.
So, it's better use full path.